### PR TITLE
add support for DOM selectors

### DIFF
--- a/test/domselectors.html
+++ b/test/domselectors.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+
+<html xmlns:th="http://www.thymeleaf.org">
+	<head>
+		<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>		
+		<script src="../thymeleaf-fragment.js" defer="defer"></script>
+	</head>
+	<body>
+		<div id="include" th:include="fragments :: p"></div>
+	</body>
+</html>

--- a/test/thymeleaf-fragment-test.js
+++ b/test/thymeleaf-fragment-test.js
@@ -1,5 +1,10 @@
 describe("thymeleaf-fragment.js", function() {
-	
+
+	it("should include fragments with DOM selectors", function() {
+		browser.driver.get("http://localhost:8080/test/domselectors.html");
+		expect(browser.driver.findElement(by.id("include")).getText()).toEqual("y");
+	});
+
 	it("should include fragments", function() {
 		browser.driver.get("http://localhost:8080/test/include.html");
 		

--- a/thymeleaf-fragment.js
+++ b/thymeleaf-fragment.js
@@ -37,11 +37,11 @@ function ThymeleafFragment() {
 	
 	var resolveFragmentUri = function(fragmentSpec) {
 		var tokens = fragmentSpec.split("::");
-		var templateName = tokens[0];
-		var fragmentName = removeFragmentParameters(tokens[1]);
+		var templateName = tokens[0].trim();
+		var fragmentName = removeFragmentParameters(tokens[1]).trim();
 		
 		var resourceName = resolveTemplate(templateName);
-		var fragmentSelector = "[th\\:fragment^='" + fragmentName + "']";
+		var fragmentSelector = "[th\\:fragment^='" + fragmentName + "']," + fragmentName;
 
 		return resourceName + " " + fragmentSelector;
 	}


### PR DESCRIPTION
This PR adds possibility of referencing fragments by id, class or tag name, as outlined here: 
http://www.thymeleaf.org/doc/articles/layouts.html#including-with-dom-selectors

Includes also fix for #5 .