### PR TITLE
Feature: Externalise configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,4 +110,31 @@ The template `widgetsView.html` can define `app/` to be the base URL for the fra
 
 The `th:if` attribute causes the template's base URL to be set when prototyping but not at runtime.
 
+Configuration
+-------------
+
+To specify the prefix and suffix used for template resolution, use `data-template-prefix` and `data-template-suffix`
+attributes on the script tag in your template.
+
+Consider a standard [Spring Boot](https://projects.spring.io/spring-boot/) application, with a directory structure as follows:
+
+```
+resources/
++- templates/
+|  +- page.html
+|  +- fragments.html
++- static/
+   +- logo.png
+```
+
+The base URL is set to correctly to load static content (images, stylesheets and fonts), and the template prefix
+locates the template relative to this.
+
+```html
+<base href="../static/" th:if="false"/>
+<script src="http://blackpeppersoftware.github.io/thymeleaf-fragment.js/thymeleaf-fragment.js"
+	data-template-prefix="../templates/" data-template-suffix=".html"
+	defer="defer" th:if="false"></script>
+```
+
 [![Build Status](https://travis-ci.org/BlackPepperSoftware/thymeleaf-fragment.js.svg?branch=master)](https://travis-ci.org/BlackPepperSoftware/thymeleaf-fragment.js)

--- a/test/config-template.html
+++ b/test/config-template.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+
+<html xmlns:th="http://www.thymeleaf.org">
+	<head>
+		<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+		<script src="../thymeleaf-fragment.js" data-template-prefix="templates/" data-template-suffix=".inc" defer="defer"></script>
+		<script src="loaded.js"></script>
+	</head>
+	<body>
+		<main><div th:include="fragments2::simple"></div></main>
+	</body>
+</html>

--- a/test/templates/fragments2.inc
+++ b/test/templates/fragments2.inc
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+
+<html xmlns:th="http://www.thymeleaf.org">
+	<body>
+		<span th:fragment="simple">a</span>
+	</body>
+</html>

--- a/test/thymeleaf-fragment.spec.js
+++ b/test/thymeleaf-fragment.spec.js
@@ -137,6 +137,15 @@ describe('thymeleaf-fragment.js', function() {
 		});
 
 	});
+
+	describe('external config', function() {
+
+		it('should use config to locate templates', function() {
+			load('config-template.html');
+
+			expect(getMainInnerHtml()).toEqual('<div>a</div>');
+		});
+	});
 	
 	var load = function(file) {
 		browser.driver.get('http://localhost:8080/test/' + file);

--- a/thymeleaf-fragment.js
+++ b/thymeleaf-fragment.js
@@ -4,12 +4,12 @@
  * See: https://github.com/BlackPepperSoftware/thymeleaf-fragment.js
  */
 function ThymeleafFragment() {
-
-	// Prefix that gets prepended to view names when building a URL
-	var templatePrefix = '';
-
-	// Suffix that gets appended to view names when building a URL
-	var templateSuffix = '.html';
+	/*
+	 * Configuration is specified using "data-" attributes on <script> tag.
+	 *  data-template-prefix - Prefix that gets prepended to view names when building a URL (default '')
+	 *  data-template-suffix - Suffix that gets appended to view names when building a URL (default '.html')
+	 */
+	var config = getConfig();
 
 	this.processAttributes = function() {
 		// Hold off scripts waiting for the document to be ready
@@ -23,6 +23,14 @@ function ThymeleafFragment() {
 			$.holdReady(false);
 		});
 	};
+
+	function getConfig() {
+		var script = $('script[src$="/thymeleaf-fragment.js"]');
+		return {
+			templatePrefix: script.attr('data-template-prefix') || '',
+			templateSuffix: script.attr('data-template-suffix') || '.html'
+		}
+	}
 
 	function addPromises(promises, element) {
 		$('[th\\:include]', element).each(function() {
@@ -80,7 +88,7 @@ function ThymeleafFragment() {
 
 	function resolveTemplate(templateName) {
 		var link = document.createElement('a');
-		link.href = templatePrefix + templateName + templateSuffix;
+		link.href = config.templatePrefix + templateName + config.templateSuffix;
 		return link.href;
 	}
 

--- a/thymeleaf-fragment.js
+++ b/thymeleaf-fragment.js
@@ -24,7 +24,7 @@ function ThymeleafFragment() {
 		});
 	};
 
-	var addPromises = function(promises, element) {
+	function addPromises(promises, element) {
 		$('[th\\:include]', element).each(function() {
 			var fragmentSpec = $(this).attr('th:include');
 			var fragmentUri = resolveFragmentUri(fragmentSpec);
@@ -44,9 +44,9 @@ function ThymeleafFragment() {
 			var fragmentUri = resolveFragmentUri(fragmentSpec);
 			promises.push(createLoadPromise(promises, this, fragmentUri, true, false));
 		});
-	};
+	}
 	
-	var resolveFragmentUri = function(fragmentSpec) {
+	function resolveFragmentUri(fragmentSpec) {
 		var tokens = fragmentSpec.trim().split(/\s*::\s*/);
 		var templateName = tokens[0];
 		var fragmentExpression = tokens[1];
@@ -59,9 +59,9 @@ function ThymeleafFragment() {
 		}
 		
 		return resourceName + ' ' + fragmentSelector;
-	};
+	}
 	
-	var parseFragmentExpression = function(fragmentExpression) {
+	function parseFragmentExpression(fragmentExpression) {
 		if (fragmentExpression === undefined) {
 			return undefined;
 		}
@@ -76,15 +76,15 @@ function ThymeleafFragment() {
 		var fragmentNameRegex = /([^()]*)/;
 		var fragmentNameOrDomSelector = fragmentExpression.match(fragmentNameRegex)[1];
 		return '[th\\:fragment^="' + fragmentNameOrDomSelector + '"], ' + fragmentNameOrDomSelector;
-	};
+	}
 
-	var resolveTemplate = function(templateName) {
+	function resolveTemplate(templateName) {
 		var link = document.createElement('a');
 		link.href = templatePrefix + templateName + templateSuffix;
 		return link.href;
-	};
+	}
 
-	var createLoadPromise = function(promises, element, url, replaceHost, insertOnlyContents) {
+	function createLoadPromise(promises, element, url, replaceHost, insertOnlyContents) {
 		return $.Deferred(function(deferred) {
 			$(element).load(url, function() {
 				var fragment = $(element).children().first().get();
@@ -105,7 +105,7 @@ function ThymeleafFragment() {
 				deferred.resolve();
 			});
 		}).promise();
-	};
+	}
 }
 
 new ThymeleafFragment().processAttributes();


### PR DESCRIPTION
Instead of needing to edit `thymeleaf-fragment.js` to configure `templatePrefix` and `templateSuffix` to match your use, this change enables these parameters to be specified as `data-*` attributes.

This should address Issue #1.